### PR TITLE
Fix list of `hubot heroku` commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ The API key can be obtained here.
 Use `hubot help` to look for the commands. They are all prefixed by heroku. (e.g. `hubot heroku restart my-app`)
 Some commands (hubot help will be a better source of truth):
 
-    hubot heroku info <app> - Returns useful information about the app
-    hubot heroku releases <app> - Latest 10 releases
-    hubot heroku rollback <app> <version> - Rollback to a release
-    hubot heroku restart <app> - Restarts the app
-    hubot heroku migrate <app> - Runs migrations. Remember to restart the app =)
-    hubot heroku config <app> - Get config keys for the app. Values not given for security
-    hubot heroku config:set <app> <KEY=value> - Set KEY to value. Case sensitive and overrides present key
-    hubot heroku config:unset <app> <KEY> - Unsets KEY, does not throw error if key is not present
+- `hubot heroku info <app>` - Returns useful information about the app
+- `hubot heroku releases <app>` - Latest 10 releases
+- `hubot heroku rollback <app>` <version> - Rollback to a release
+- `hubot heroku restart <app>` - Restarts the app
+- `hubot heroku migrate <app>` - Runs migrations. Remember to restart the app =)
+- `hubot heroku config <app>` - Get config keys for the app. Values not given for security
+- `hubot heroku config:set <app> <KEY=value>` - Set KEY to value. Case sensitive and overrides present key
+- `hubot heroku config:unset <app> <KEY>` - Unsets KEY, does not throw error if key is not present
 
 For example, `hubot heroku config:set API_KEY=12345`
 


### PR DESCRIPTION
The list of commands now render correctly in markdown