### PR TITLE
Fix heroku set command

### DIFF
--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -131,8 +131,10 @@ module.exports = (robot) ->
       listOfKeys = configVars && Object.keys(configVars).join(", ")
       respondToUser(msg, error, listOfKeys)
 
-  robot.respond /heroku config:set (.*) (\w+)=(\w+)/i, (msg) ->
+  robot.respond /heroku config:set (.*) (\w+)=(.*)/i, (msg) ->
     keyPair = {}
+
+
     appName = msg.match[1]
     key     = msg.match[2]
     value   = msg.match[3]

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -131,7 +131,7 @@ module.exports = (robot) ->
       listOfKeys = configVars && Object.keys(configVars).join(", ")
       respondToUser(msg, error, listOfKeys)
 
-  robot.respond /heroku config:set (.*) (\w+)=(.*)/i, (msg) ->
+  robot.respond /heroku config:set (.*) (\w+)=(.+)/i, (msg) ->
     keyPair = {}
 
 

--- a/test/fixtures/config-set.json
+++ b/test/fixtures/config-set.json
@@ -1,1 +1,1 @@
-{ "CLOAK_ID": "10" }
+{ "CLOAK_ID": "example.com" }

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -153,14 +153,14 @@ describe "Heroku Commands", ->
     it "sets config <KEY=value>", (done) ->
       mockHeroku
         .patch("/apps/shield-global-watch/config-vars",
-          "CLOAK_ID": 10
+          "CLOAK_ID": 'example.com'
         ).replyWithFile(200, __dirname + "/fixtures/config-set.json")
 
-      room.user.say "Damon", "hubot heroku config:set shield-global-watch CLOAK_ID=10"
+      room.user.say "Damon", "hubot heroku config:set shield-global-watch CLOAK_ID=example.com"
 
       setTimeout(->
-        expect(room.messages[1][1]).to.equal("@Damon Setting config CLOAK_ID => 10")
-        expect(room.messages[2][1]).to.equal("@Damon Heroku: CLOAK_ID is set to 10")
+        expect(room.messages[1][1]).to.equal("@Damon Setting config CLOAK_ID => example.com")
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: CLOAK_ID is set to example.com")
         done()
       , duration)
 


### PR DESCRIPTION
# What's up

The regex we were using to parse the set command only accepted word characters so it missed everything with a . for example. 

Solves #7 