### PR TITLE
move dotenv to dependencies in package.json since index.coffee needs it ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "homepage": "https://github.com/daemonsy/hubot-heroku",
   "dependencies": {
     "heroku-client": "^1.9.0",
+    "dotenv": "^0.4.0",
     "lodash": "^2.4.1"
   },
   "devDependencies": {
     "chai": "^1.10.0",
     "coffee-script": "^1.8.0",
-    "dotenv": "^0.4.0",
     "hubot": "^2.9.3",
     "hubot-scripts": "^2.5.16",
     "hubot-test-helper": "0.0.2",


### PR DESCRIPTION
...and heroku doesn't install devDependencies

I could be wrong here, but I think the dotenv npm package was installed as a devDependency instead of a normal dependency, which led to it not being defined once I deployed to Heroku. I did a work around and just installed the dotenv on my hubot instance, but I think this a better solution.

Awesome script by the way.