### PR TITLE
Don't use dotenv in all environments, only in tests.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+## Contributors
+
+- @jhendley25: #11 - Move dotenv to dependencies in package.json since index.coffee needs it

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ node-inspector --no-preload --web-port 8123
 
 ### Get hubot to run with debugging on
 ```bash
+# In your hubot folder
+npm link /path/to/hubot-heroku
 coffee --nodejs --debug node_modules/.bin/hubot
 ```
 

--- a/index.coffee
+++ b/index.coffee
@@ -1,7 +1,6 @@
 # description:
 #  Entry Point
 path = require 'path'
-require('dotenv').load()
 
 module.exports = (robot, scripts) ->
   robot.loadFile(path.resolve(__dirname, "src", "scripts"), "heroku-commands.coffee")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-heroku",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Run heroku commands via hubot without direct access to Heroku",
   "main": "index.js",
   "scripts": {

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -17,9 +17,6 @@
 #   hubot heroku config:set <app> <KEY=value> - Set KEY to value. Case sensitive and overrides present key
 #   hubot heroku config:unset <app> <KEY> - Unsets KEY, does not throw error if key is not present
 #
-# Notes:
-#   Very alpha
-#
 # Author:
 #   daemonsy
 

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -1,3 +1,5 @@
+require('dotenv').load()
+
 HubotHelper = require("hubot-test-helper")
 path = require("path")
 chai = require("chai")


### PR DESCRIPTION
## What's up?

- This is a hubot addon, the ENV dependencies should be managed on the main hubot app
- Don't wish to add bloat / side-effects to hubot installations

