### PR TITLE
Fix set command

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 ## Contributors
 
 - @jhendley25: #11 - Move dotenv to dependencies in package.json since index.coffee needs it
+- Mikhail Dubov <mdubov@gmail.com>: #8 - Fix heroku set command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-heroku",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Run heroku commands via hubot without direct access to Heroku",
   "main": "index.js",
   "scripts": {

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -131,8 +131,10 @@ module.exports = (robot) ->
       listOfKeys = configVars && Object.keys(configVars).join(", ")
       respondToUser(msg, error, listOfKeys)
 
-  robot.respond /heroku config:set (.*) (\w+)=(\w+)/i, (msg) ->
+  robot.respond /heroku config:set (.*) (\w+)=(.*)/i, (msg) ->
     keyPair = {}
+
+
     appName = msg.match[1]
     key     = msg.match[2]
     value   = msg.match[3]

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -131,7 +131,7 @@ module.exports = (robot) ->
       listOfKeys = configVars && Object.keys(configVars).join(", ")
       respondToUser(msg, error, listOfKeys)
 
-  robot.respond /heroku config:set (.*) (\w+)=(.*)/i, (msg) ->
+  robot.respond /heroku config:set (.*) (\w+)=(.+)/i, (msg) ->
     keyPair = {}
 
 

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -131,13 +131,12 @@ module.exports = (robot) ->
       listOfKeys = configVars && Object.keys(configVars).join(", ")
       respondToUser(msg, error, listOfKeys)
 
-  robot.respond /heroku config:set (.*) (\w+)=(.+)/i, (msg) ->
+  robot.respond /heroku config:set (.*) (\w+)=('(.+)'|"(.+)"|(.+\b))/i, (msg) ->
     keyPair = {}
-
 
     appName = msg.match[1]
     key     = msg.match[2]
-    value   = msg.match[3]
+    value   = msg.match[4] || msg.match[5] || msg.match[6] # :sad_panda:
 
     msg.reply "Setting config #{key} => #{value}"
 

--- a/test/fixtures/config-set.json
+++ b/test/fixtures/config-set.json
@@ -1,1 +1,8 @@
-{ "CLOAK_ID": "example.com" }
+{
+  "CLOAK_ID"               : "example.com",
+  "UUID"                   : "d5126f0d-b3be-46af-883f-b330a73964f9",
+  "PUSHER_URL"             : "http://c0d9g8najfcc4634kd3:cf2eeas0d8dghfa847d@api.pusherapp.com/apps/1234",
+  "RSA_SECRET_KEY"         : "\"----BEGIN RSA PRIVATE KEY-----\nsfsdfdssfdsFDSFDGSDfsdfsfs\nSDfSDFdUbOfFRocKsSFDSFSDFDS=\n-----END RSA PRIVATE KEY-----\n\"",
+  "COMMA_DELIMITED_STRING" : "MiD,DA,MDe",
+  "SENTENCE"               : "Don't stop believin."
+}

--- a/test/fixtures/config-set.json
+++ b/test/fixtures/config-set.json
@@ -1,1 +1,1 @@
-{ "CLOAK_ID": "10" }
+{ "CLOAK_ID": "example.com" }

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -2,6 +2,7 @@ HubotHelper = require("hubot-test-helper")
 path = require("path")
 chai = require("chai")
 nock = require("nock")
+
 process.env.HUBOT_HEROKU_API_KEY = 'fake_key'
 
 { expect } = chai
@@ -150,11 +151,13 @@ describe "Heroku Commands", ->
       )
 
   describe "heroku config:set <app> <KEY=value>", ->
-    it "sets config <KEY=value>", (done) ->
+    mockRequest = (keyPair) ->
       mockHeroku
-        .patch("/apps/shield-global-watch/config-vars",
-          "CLOAK_ID": 'example.com'
-        ).replyWithFile(200, __dirname + "/fixtures/config-set.json")
+        .patch("/apps/shield-global-watch/config-vars",keyPair)
+        .replyWithFile(200, __dirname + "/fixtures/config-set.json")
+
+    it "sets config <KEY=value>", (done) ->
+      mockRequest({ "CLOAK_ID": "example.com" })
 
       room.user.say "Damon", "hubot heroku config:set shield-global-watch CLOAK_ID=example.com"
 
@@ -163,6 +166,57 @@ describe "Heroku Commands", ->
         expect(room.messages[2][1]).to.equal("@Damon Heroku: CLOAK_ID is set to example.com")
         done()
       , duration)
+
+    it "handles UUIDs", (done) ->
+      mockRequest("UUID": "d5126f0d-b3be-46af-883f-b330a73964f9")
+
+      room.user.say "Damon", "hubot heroku config:set shield-global-watch UUID=d5126f0d-b3be-46af-883f-b330a73964f9"
+
+      setTimeout(->
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: UUID is set to d5126f0d-b3be-46af-883f-b330a73964f9")
+        done()
+      , duration)
+
+    it "handles URLs", (done) ->
+      mockRequest("PUSHER_URL": "http://c0d9g8najfcc4634kd3:cf2eeas0d8dghfa847d@api.pusherapp.com/apps/1234")
+
+      room.user.say "Damon", "hubot heroku config:set shield-global-watch PUSHER_URL=http://c0d9g8najfcc4634kd3:cf2eeas0d8dghfa847d@api.pusherapp.com/apps/1234"
+
+      setTimeout(->
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: PUSHER_URL is set to http://c0d9g8najfcc4634kd3:cf2eeas0d8dghfa847d@api.pusherapp.com/apps/1234")
+        done()
+      , duration)
+
+    it "handles comma delimited strings", (done) ->
+      mockRequest("COMMA_DELIMITED_STRING": "MiD,DA,MDe")
+
+      room.user.say "Damon", "hubot heroku config:set shield-global-watch COMMA_DELIMITED_STRING=MiD,DA,MDe"
+
+      setTimeout(->
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: COMMA_DELIMITED_STRING is set to MiD,DA,MDe")
+        done()
+      , duration)
+
+    it "handles text strings", (done) ->
+      mockRequest("SENTENCE": "Don\'t stop believin.")
+
+      room.user.say "Damon", "hubot heroku config:set shield-global-watch SENTENCE=\"Don't stop believin.\""
+
+      setTimeout(->
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: SENTENCE is set to Don\'t stop believin.")
+        done()
+      , duration)
+
+    xit "handles RSA secret keys", (done) ->
+      mockRequest("RSA_SECRET_KEY": "\"----BEGIN RSA PRIVATE KEY-----\nsfsdfdssfdsFDSFDGSDfsdfsfs\nSDfSDFdUbOfFRocKsSFDSFSDFDS=\n-----END RSA PRIVATE KEY-----\n\"")
+
+      room.user.say "Damon", "hubot heroku config:set shield-global-watch RSA_SECRET_KEY=\"----BEGIN RSA PRIVATE KEY-----\nsfsdfdssfdsFDSFDGSDfsdfsfs\nSDfSDFdUbOfFRocKsSFDSFSDFDS=\n-----END RSA PRIVATE KEY-----\n\""
+
+      setTimeout(->
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: RSA_SECRET_KEY is set to ----BEGIN RSA PRIVATE KEY-----\nsfsdfdssfdsFDSFDGSDfsdfsfs\nSDfSDFdUbOfFRocKsSFDSFSDFDS=\n-----END RSA PRIVATE KEY-----\n")
+        done()
+      , duration)
+
 
   describe "heroku config:unset <KEY>", ->
     it "unsets config <KEY>", (done) ->

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -153,14 +153,14 @@ describe "Heroku Commands", ->
     it "sets config <KEY=value>", (done) ->
       mockHeroku
         .patch("/apps/shield-global-watch/config-vars",
-          "CLOAK_ID": 10
+          "CLOAK_ID": 'example.com'
         ).replyWithFile(200, __dirname + "/fixtures/config-set.json")
 
-      room.user.say "Damon", "hubot heroku config:set shield-global-watch CLOAK_ID=10"
+      room.user.say "Damon", "hubot heroku config:set shield-global-watch CLOAK_ID=example.com"
 
       setTimeout(->
-        expect(room.messages[1][1]).to.equal("@Damon Setting config CLOAK_ID => 10")
-        expect(room.messages[2][1]).to.equal("@Damon Heroku: CLOAK_ID is set to 10")
+        expect(room.messages[1][1]).to.equal("@Damon Setting config CLOAK_ID => example.com")
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: CLOAK_ID is set to example.com")
         done()
       , duration)
 


### PR DESCRIPTION
## What's up? 

`hubot heroku config:set xyz-app ABC=example.com` breaks because the regex matcher is too simplistic. 

This updates it to accept the common type of values, such as UUIDs, URIs, sentences. 

I got a small snag when trying to deal with naked `\n`. Any help is greatly appreciated.

Derived from From https://github.com/daemonsy/hubot-heroku/pull/8 