### PR TITLE
Add support for multiline configuration values

### DIFF
--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -128,7 +128,7 @@ module.exports = (robot) ->
       listOfKeys = configVars && Object.keys(configVars).join(", ")
       respondToUser(msg, error, listOfKeys)
 
-  robot.respond /heroku config:set (.*) (\w+)=('(.+)'|"(.+)"|(.+\b))/i, (msg) ->
+  robot.respond /heroku config:set (.*) (\w+)=('([\s\S]+)'|"([\s\S]+)"|([\s\S]+\b))/im, (msg) ->
     keyPair = {}
 
     appName = msg.match[1]

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -209,13 +209,13 @@ describe "Heroku Commands", ->
         done()
       , duration)
 
-    xit "handles RSA secret keys", (done) ->
-      mockRequest("RSA_SECRET_KEY": "\"----BEGIN RSA PRIVATE KEY-----\nsfsdfdssfdsFDSFDGSDfsdfsfs\nSDfSDFdUbOfFRocKsSFDSFSDFDS=\n-----END RSA PRIVATE KEY-----\n\"")
+    it "handles RSA secret keys", (done) ->
+      mockRequest("RSA_SECRET_KEY": "----BEGIN RSA PRIVATE KEY-----\nsfsdfdssfdsFDSFDGSDfsdfsfs\nSDfSDFdUbOfFRocKsSFDSFSDFDS=\n-----END RSA PRIVATE KEY-----\n")
 
       room.user.say "Damon", "hubot heroku config:set shield-global-watch RSA_SECRET_KEY=\"----BEGIN RSA PRIVATE KEY-----\nsfsdfdssfdsFDSFDGSDfsdfsfs\nSDfSDFdUbOfFRocKsSFDSFSDFDS=\n-----END RSA PRIVATE KEY-----\n\""
 
       setTimeout(->
-        expect(room.messages[2][1]).to.equal("@Damon Heroku: RSA_SECRET_KEY is set to ----BEGIN RSA PRIVATE KEY-----\nsfsdfdssfdsFDSFDGSDfsdfsfs\nSDfSDFdUbOfFRocKsSFDSFSDFDS=\n-----END RSA PRIVATE KEY-----\n")
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: RSA_SECRET_KEY is set to \"----BEGIN RSA PRIVATE KEY-----\nsfsdfdssfdsFDSFDGSDfsdfsfs\nSDfSDFdUbOfFRocKsSFDSFSDFDS=\n-----END RSA PRIVATE KEY-----\n\"")
         done()
       , duration)
 


### PR DESCRIPTION
This PR enables multiline configuration values to be passed in when using `heroku config:set`.