### PR TITLE
Allow specific dynos to be restarted and viewing of dyno list and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Use `hubot help` to look for the commands. They are all prefixed by heroku. (e.g
 Some commands (hubot help will be a better source of truth):
 
 - `hubot heroku info <app>` - Returns useful information about the app
+- `hubot heroku dynos <app>` - Lists all dynos and their status
 - `hubot heroku releases <app>` - Latest 10 releases
 - `hubot heroku rollback <app>` <version> - Rollback to a release
 - `hubot heroku restart <app> <dyno>` - Restarts the specified app or dyno/s (e.g. `worker` or `web.2`)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Some commands (hubot help will be a better source of truth):
 - `hubot heroku info <app>` - Returns useful information about the app
 - `hubot heroku releases <app>` - Latest 10 releases
 - `hubot heroku rollback <app>` <version> - Rollback to a release
-- `hubot heroku restart <app>` - Restarts the app
+- `hubot heroku restart <app> <dyno>` - Restarts the specified app or dyno/s
 - `hubot heroku migrate <app>` - Runs migrations. Remember to restart the app =)
 - `hubot heroku config <app>` - Get config keys for the app. Values not given for security
 - `hubot heroku config:set <app> <KEY=value>` - Set KEY to value. Case sensitive and overrides present key

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Some commands (hubot help will be a better source of truth):
 - `hubot heroku info <app>` - Returns useful information about the app
 - `hubot heroku releases <app>` - Latest 10 releases
 - `hubot heroku rollback <app>` <version> - Rollback to a release
-- `hubot heroku restart <app> <dyno>` - Restarts the specified app or dyno/s
+- `hubot heroku restart <app> <dyno>` - Restarts the specified app or dyno/s (e.g. `worker` or `web.2`)
 - `hubot heroku migrate <app>` - Runs migrations. Remember to restart the app =)
 - `hubot heroku config <app>` - Get config keys for the app. Values not given for security
 - `hubot heroku config:set <app> <KEY=value>` - Set KEY to value. Case sensitive and overrides present key

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/daemonsy/hubot-heroku",
   "dependencies": {
     "heroku-client": "^1.9.0",
-    "lodash": "^2.4.1"
+    "lodash": "^2.4.1",
+    "moment": "^2.10.3"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -11,7 +11,7 @@
 #   hubot heroku info <app> - Returns useful information about the app
 #   hubot heroku releases <app> - Latest 10 releases
 #   hubot heroku rollback <app> <version> - Rollback to a release
-#   hubot heroku restart <app> - Restarts the app
+#   hubot heroku restart <app> <dyno> - Restarts the specified app or dyno/s
 #   hubot heroku migrate <app> - Runs migrations. Remember to restart the app =)
 #   hubot heroku config <app> - Get config keys for the app. Values not given for security
 #   hubot heroku config:set <app> <KEY=value> - Set KEY to value. Case sensitive and overrides present key
@@ -91,13 +91,18 @@ module.exports = (robot) ->
           respondToUser(msg, error, "Success! v#{release.version} -> Rollback to #{version}")
 
   # Restart
-  robot.respond /heroku restart (.*)/i, (msg) ->
+  robot.respond /heroku restart ([\w-]+)\s?(\w+(?:\.\d+)?)?/i, (msg) ->
     appName = msg.match[1]
+    dynoName = msg.match[2] or ''
 
-    msg.reply "Telling Heroku to restart #{appName}"
+    msg.reply "Telling Heroku to restart #{appName} #{dynoName}"
 
-    heroku.apps(appName).dynos().restartAll (error, app) ->
-      respondToUser(msg, error, "Heroku: Restarting #{appName}")
+    unless dynoName
+      heroku.apps(appName).dynos().restartAll (error, app) ->
+        respondToUser(msg, error, "Heroku: Restarting #{appName}")
+    else
+      heroku.apps(appName).dynos(dynoName).restart (error, app) ->
+        respondToUser(msg, error, "Heroku: Restarting #{appName} #{dynoName}")
 
   # Migration
   robot.respond /heroku migrate (.*)/i, (msg) ->

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -93,16 +93,17 @@ module.exports = (robot) ->
   # Restart
   robot.respond /heroku restart ([\w-]+)\s?(\w+(?:\.\d+)?)?/i, (msg) ->
     appName = msg.match[1]
-    dynoName = msg.match[2] or ''
+    dynoName = msg.match[2]
+    dynoNameText = if dynoName then ' '+dynoName else ''
 
-    msg.reply "Telling Heroku to restart #{appName}#{if dynoName then ' '+dynoName else ''}"
+    msg.reply "Telling Heroku to restart #{appName}#{dynoNameText}"
 
     unless dynoName
       heroku.apps(appName).dynos().restartAll (error, app) ->
         respondToUser(msg, error, "Heroku: Restarting #{appName}")
     else
       heroku.apps(appName).dynos(dynoName).restart (error, app) ->
-        respondToUser(msg, error, "Heroku: Restarting #{appName}#{if dynoName then ' '+dynoName else ''}")
+        respondToUser(msg, error, "Heroku: Restarting #{appName}#{dynoNameText}")
 
   # Migration
   robot.respond /heroku migrate (.*)/i, (msg) ->

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -11,7 +11,7 @@
 #   hubot heroku info <app> - Returns useful information about the app
 #   hubot heroku releases <app> - Latest 10 releases
 #   hubot heroku rollback <app> <version> - Rollback to a release
-#   hubot heroku restart <app> <dyno> - Restarts the specified app or dyno/s
+#   hubot heroku restart <app> <dyno> - Restarts the specified app or dyno/s (e.g. worker or web.2)
 #   hubot heroku migrate <app> - Runs migrations. Remember to restart the app =)
 #   hubot heroku config <app> - Get config keys for the app. Values not given for security
 #   hubot heroku config:set <app> <KEY=value> - Set KEY to value. Case sensitive and overrides present key

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -9,6 +9,7 @@
 #
 # Commands:
 #   hubot heroku info <app> - Returns useful information about the app
+#   hubot heroku dynos <app> - Lists all dynos and their status
 #   hubot heroku releases <app> - Latest 10 releases
 #   hubot heroku rollback <app> <version> - Rollback to a release
 #   hubot heroku restart <app> <dyno> - Restarts the specified app or dyno/s (e.g. worker or web.2)

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -95,14 +95,14 @@ module.exports = (robot) ->
     appName = msg.match[1]
     dynoName = msg.match[2] or ''
 
-    msg.reply "Telling Heroku to restart #{appName} #{dynoName}"
+    msg.reply "Telling Heroku to restart #{appName}#{if dynoName then ' '+dynoName else ''}"
 
     unless dynoName
       heroku.apps(appName).dynos().restartAll (error, app) ->
         respondToUser(msg, error, "Heroku: Restarting #{appName}")
     else
       heroku.apps(appName).dynos(dynoName).restart (error, app) ->
-        respondToUser(msg, error, "Heroku: Restarting #{appName} #{dynoName}")
+        respondToUser(msg, error, "Heroku: Restarting #{appName}#{if dynoName then ' '+dynoName else ''}")
 
   # Migration
   robot.respond /heroku migrate (.*)/i, (msg) ->

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -63,7 +63,7 @@ module.exports = (robot) ->
 
     msg.reply "Getting dynos of #{appName}"
 
-    heroku.apps(appName).info (error, dynos) ->
+    heroku.apps(appName).dynos().list (error, dynos) ->
       output = []
       if dynos
         output.push "Dynos of #{appName}"
@@ -77,9 +77,10 @@ module.exports = (robot) ->
             output.push "=== #{dyno.type} (#{dyno.size}): `#{dyno.command}`"
             lastFormation = currentFormation
 
-          updatedAt = moment(dyno.updated_at, 'YYYY/MM/DD HH:mm:ss')
-          timeAgo = moment(dyno.updated_at).fromNow()
-          output.push "#{dyno.name}: #{dyno.state} #{updatedAt} (~ #{timeAgo})"
+          updatedAt = moment(dyno.updated_at)
+          updatedTime = updatedAt.format('YYYY/MM/DD HH:mm:ss')
+          timeAgo = updatedAt.fromNow()
+          output.push "#{dyno.name}: #{dyno.state} #{updatedTime} (~ #{timeAgo})"
 
       respondToUser(msg, error, output.join("\n"))
 

--- a/test/fixtures/dynos.json
+++ b/test/fixtures/dynos.json
@@ -1,0 +1,47 @@
+[
+  {
+    "attach_url": "rendezvous://rendezvous.runtime.heroku.com:5000/{rendezvous-id}",
+    "command": "forever server.js",
+    "created_at": "2012-01-01T12:00:00Z",
+    "id": "01234567-89ab-cdef-0123-456789abcdef",
+    "name": "web.1",
+    "release": {
+      "id": "01234567-89ab-cdef-0123-456789abcdef",
+      "version": 11
+    },
+    "size": "1X",
+    "state": "up",
+    "type": "web",
+    "updated_at": "2015-01-01T12:00:00Z"
+  },
+  {
+    "attach_url": "rendezvous://rendezvous.runtime.heroku.com:5000/{rendezvous-id}",
+    "command": "forever server.js",
+    "created_at": "2012-01-01T12:00:00Z",
+    "id": "01234567-89ab-cdef-0123-456789abcdef",
+    "name": "web.2",
+    "release": {
+      "id": "01234567-89ab-cdef-0123-456789abcdef",
+      "version": 11
+    },
+    "size": "1X",
+    "state": "crashed",
+    "type": "web",
+    "updated_at": "2015-01-01T12:00:00Z"
+  },
+  {
+    "attach_url": "rendezvous://rendezvous.runtime.heroku.com:5000/{rendezvous-id}",
+    "command": "celery worker",
+    "created_at": "2012-01-01T12:00:00Z",
+    "id": "01234567-89ab-cdef-0123-456789abcdef",
+    "name": "worker.1",
+    "release": {
+      "id": "01234567-89ab-cdef-0123-456789abcdef",
+      "version": 11
+    },
+    "size": "2X",
+    "state": "up",
+    "type": "worker",
+    "updated_at": "2015-06-01T12:00:00Z"
+  }
+]

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -30,7 +30,7 @@ describe "Heroku Commands", ->
     expect(commands).to.include("hubot heroku info <app> - Returns useful information about the app")
     expect(commands).to.include("hubot heroku releases <app> - Latest 10 releases")
     expect(commands).to.include("hubot heroku rollback <app> <version> - Rollback to a release")
-    expect(commands).to.include("hubot heroku restart <app> - Restarts the app")
+    expect(commands).to.include("hubot heroku restart <app> <dyno> - Restarts the specified app or dyno/s")
     expect(commands).to.include("hubot heroku migrate <app> - Runs migrations. Remember to restart the app =)")
     expect(commands).to.include("hubot heroku config <app> - Get config keys for the app. Values not given for security")
     expect(commands).to.include("hubot heroku config:set <app> <KEY=value> - Set KEY to value. Case sensitive and overrides present key")
@@ -94,7 +94,7 @@ describe "Heroku Commands", ->
         done()
       , duration)
 
-  describe "heroku restart <app>", ->
+  describe "heroku restart <app> <dyno>", ->
     it "restarts the app", (done) ->
       mockHeroku
         .delete("/apps/shield-global-watch/dynos")
@@ -105,6 +105,32 @@ describe "Heroku Commands", ->
       setTimeout(->
         expect(room.messages[1][1]).to.equal("@Damon Telling Heroku to restart shield-global-watch")
         expect(room.messages[2][1]).to.equal("@Damon Heroku: Restarting shield-global-watch")
+        done()
+      , duration)
+
+    it "restarts all dynos of a process", (done) ->
+      mockHeroku
+        .delete("/apps/shield-global-watch/dynos/web")
+        .reply(200, {})
+
+      room.user.say "Damon", "hubot heroku restart shield-global-watch web"
+
+      setTimeout(->
+        expect(room.messages[1][1]).to.equal("@Damon Telling Heroku to restart shield-global-watch web")
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: Restarting shield-global-watch web")
+        done()
+      , duration)
+
+    it "restarts specific dynos", (done) ->
+      mockHeroku
+        .delete("/apps/shield-global-watch/dynos/web.1")
+        .reply(200, {})
+
+      room.user.say "Damon", "hubot heroku restart shield-global-watch web.1"
+
+      setTimeout(->
+        expect(room.messages[1][1]).to.equal("@Damon Telling Heroku to restart shield-global-watch web.1")
+        expect(room.messages[2][1]).to.equal("@Damon Heroku: Restarting shield-global-watch web.1")
         done()
       , duration)
 
@@ -150,7 +176,7 @@ describe "Heroku Commands", ->
         expect(room.messages[1][1]).to.equal("@Damon Getting config keys for shield-global-watch")
         expect(room.messages[2][1]).to.equal("@Damon CLOAK, COMMANDER, AUTOPILOT, PILOT_NAME")
         done()
-      )
+      , duration)
 
   describe "heroku config:set <app> <KEY=value>", ->
     mockRequest = (keyPair) ->
@@ -234,4 +260,3 @@ describe "Heroku Commands", ->
         expect(room.messages[2][1]).to.equal("@Damon Heroku: CLOAK_ID has been unset")
         done()
       , duration)
-

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -30,7 +30,7 @@ describe "Heroku Commands", ->
     expect(commands).to.include("hubot heroku info <app> - Returns useful information about the app")
     expect(commands).to.include("hubot heroku releases <app> - Latest 10 releases")
     expect(commands).to.include("hubot heroku rollback <app> <version> - Rollback to a release")
-    expect(commands).to.include("hubot heroku restart <app> <dyno> - Restarts the specified app or dyno/s")
+    expect(commands).to.include("hubot heroku restart <app> <dyno> - Restarts the specified app or dyno/s (e.g. worker or web.2)")
     expect(commands).to.include("hubot heroku migrate <app> - Runs migrations. Remember to restart the app =)")
     expect(commands).to.include("hubot heroku config <app> - Get config keys for the app. Values not given for security")
     expect(commands).to.include("hubot heroku config:set <app> <KEY=value> - Set KEY to value. Case sensitive and overrides present key")

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -25,9 +25,10 @@ describe "Heroku Commands", ->
   it "exposes help commands", ->
     commands = room.robot.commands
 
-    expect(commands).to.have.length(8)
+    expect(commands).to.have.length(9)
 
     expect(commands).to.include("hubot heroku info <app> - Returns useful information about the app")
+    expect(commands).to.include("hubot heroku dynos <app> - Lists all dynos and their status")
     expect(commands).to.include("hubot heroku releases <app> - Latest 10 releases")
     expect(commands).to.include("hubot heroku rollback <app> <version> - Rollback to a release")
     expect(commands).to.include("hubot heroku restart <app> <dyno> - Restarts the specified app or dyno/s (e.g. worker or web.2)")

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -51,6 +51,21 @@ describe "Heroku Commands", ->
         done()
       , duration)
 
+  describe "heroku dynos <app>", ->
+    it "lists all dynos and their status", (done) ->
+      mockHeroku
+        .get("/apps/shield-global-watch/dynos")
+        .replyWithFile(200, __dirname + "/fixtures/dynos.json")
+
+      room.user.say "Damon", "hubot heroku dynos shield-global-watch"
+
+      setTimeout(->
+        expect(room.messages[1][1]).to.equal("@Damon Getting dynos of shield-global-watch")
+        expect(room.messages[2][1]).to.include("@Damon Dynos of shield-global-watch\n=== web (1X): `forever server.js`\nweb.1: up 2015/01/01 07:00:00")
+        expect(room.messages[2][1]).to.include("\nweb.2: crashed 2015/01/01 07:00:00")
+        expect(room.messages[2][1]).to.include("\n\n=== worker (2X): `celery worker`\nworker.1: up 2015/06/01 08:00:00")
+        done()
+      , duration)
 
   describe "heroku releases <app>", ->
     it "gets the 10 recent releases", (done) ->


### PR DESCRIPTION
Allows for the following types of commands:

- `hubot heroku restart my-app` (restarts all dynos on app)
- `hubot heroku restart my-app worker` (restarts all worker dynos)
- `hubot heroku restart my-app web.2` (restarts only the web.2 dyno)