### PR TITLE
Account for various hubot-auth install locations

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -3,5 +3,5 @@
 path = require 'path'
 
 module.exports = (robot, scripts) ->
-  robot.loadFile(path.resolve(__dirname, "node_modules", "hubot-auth"), "index.coffee")
+  robot.loadFile(require.resolve('hubot-auth').slice(0,-13), "index.coffee")
   robot.loadFile(path.resolve(__dirname, "src", "scripts"), "heroku-commands.coffee")


### PR DESCRIPTION
Using require instead of a simple path allows searching for hubot-auth at various levels, so whether it is installed within hubot-heroku or in the top level node_modules directory, it will be found. The current implementation creates an error for those with hubot-auth installed in the top level node_modules directory.