### PR TITLE
Add a command to list apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The API key can be obtained here.
 Use `hubot help` to look for the commands. They are all prefixed by heroku. (e.g. `hubot heroku restart my-app`)
 Some commands (hubot help will be a better source of truth):
 
+- `hubot heroku list apps <app name filter>` - Lists all apps or filtered by the name
 - `hubot heroku info <app>` - Returns useful information about the app
 - `hubot heroku dynos <app>` - Lists all dynos and their status
 - `hubot heroku releases <app>` - Latest 10 releases

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Run heroku commands via hubot without direct access to Heroku",
   "main": "index.js",
   "scripts": {
-    "test": "HUBOT_HEROKU_USE_AUTH=true node_modules/.bin/mocha"
+    "test": "node_modules/.bin/mocha"
   },
   "repository": {
     "type": "git",

--- a/src/heroku-response-mapper.coffee
+++ b/src/heroku-response-mapper.coffee
@@ -1,3 +1,5 @@
+moment = require("moment")
+
 module.exports =
   info: (response) ->
     name:         response.name
@@ -10,3 +12,9 @@ module.exports =
     git_url:      response.git_url
     buildpack:    response.buildpack_provided_description
     stack:        response.build_stack && response.build_stack.name
+
+  appShortInfo: (response) ->
+    name:         response.name
+    url:          response.web_url
+    git_url:      response.git_url
+    last_release: "#{moment(response.released_at).fromNow()} ago"

--- a/src/object-to-message.coffee
+++ b/src/object-to-message.coffee
@@ -1,0 +1,18 @@
+mapper = require('./heroku-response-mapper')
+
+rpad = (string, width, padding = ' ') ->
+  if (width <= string.length) then string else rpad(width, string + padding, padding)
+
+module.exports = (object, mapperName) ->
+  cleanedObject = mapper[mapperName](object)
+
+  output = []
+  maxLength = 0
+  keys = Object.keys(cleanedObject)
+  keys.forEach (key) ->
+    maxLength = key.length if key.length > maxLength
+
+  keys.forEach (key) ->
+    output.push "#{rpad(key, maxLength)} : #{cleanedObject[key]}"
+
+  output.join("\n")

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -22,18 +22,22 @@
 # Author:
 #   daemonsy
 
-Heroku = require('heroku-client')
+Heroku          = require('heroku-client')
+objectToMessage = require("../object-to-message")
+
 heroku = new Heroku(token: process.env.HUBOT_HEROKU_API_KEY)
 _      = require('lodash')
-mapper = require('../heroku-response-mapper')
 moment = require('moment')
 useAuth = (process.env.HUBOT_HEROKU_USE_AUTH or '').trim().toLowerCase() is 'true'
 
 module.exports = (robot) ->
   auth = (msg, appName) ->
-    role = "heroku-#{appName}"
-    hasRole = robot.auth.hasRole(msg.envelope.user, role)
+    if appName
+      role = "heroku-#{appName}"
+      hasRole = robot.auth.hasRole(msg.envelope.user, role)
+
     isAdmin = robot.auth.hasRole(msg.envelope.user, 'admin')
+
     if useAuth and not (hasRole or isAdmin)
       msg.reply "Access denied. You must have this role to use this command: #{role}"
       return false
@@ -45,31 +49,35 @@ module.exports = (robot) ->
     else
       robotMessage.reply successMessage
 
-  rpad = (string, width, padding = ' ') ->
-    if (width <= string.length) then string else rpad(width, string + padding, padding)
+  # App List
+  robot.respond /(heroku list apps)\s?(.*)/i, (msg) ->
+    return unless auth(msg)
 
-  objectToMessage = (object) ->
-    output = []
-    maxLength = 0
-    keys = Object.keys(object)
-    keys.forEach (key) ->
-      maxLength = key.length if key.length > maxLength
+    searchName = msg.match[2] if msg.match[2].length > 0
 
-    keys.forEach (key) ->
-      output.push "#{rpad(key, maxLength)} : #{object[key]}"
+    if searchName
+      msg.reply "Listing apps matching: #{searchName}"
+    else
+      msg.reply "Listing all apps available..."
 
-    output.join("\n")
+    heroku.apps().list (error, list) ->
+      list = list.filter (item) -> item.name.match(new RegExp(searchName, "i"))
+
+      result = if list.length > 0 then list.map((app) -> objectToMessage(app, "appShortInfo")).join("\n\n") else "No apps found"
+
+      respondToUser(msg, error, result)
 
   # App Info
   robot.respond /heroku info (.*)/i, (msg) ->
-    appName = msg.match[1]
-
     return unless auth(msg, appName)
+
+    appName = msg.match[1]
 
     msg.reply "Getting information about #{appName}"
 
     heroku.apps(appName).info (error, info) ->
-      respondToUser(msg, error, "\n" + objectToMessage(mapper.info(info)))
+      successMessage = "\n" + objectToMessage(info, "info") unless error
+      respondToUser(msg, error, successMessage)
 
   # Dynos
   robot.respond /heroku dynos (.*)/i, (msg) ->

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -9,6 +9,7 @@
 #   HUBOT_HEROKU_API_KEY
 #
 # Commands:
+#   hubot heroku list apps <app name filter> - Lists all apps or filtered by the name
 #   hubot heroku info <app> - Returns useful information about the app
 #   hubot heroku dynos <app> - Lists all dynos and their status
 #   hubot heroku releases <app> - Latest 10 releases

--- a/test/fixtures/app-list.json
+++ b/test/fixtures/app-list.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "shield-global-watch",
+    "web_url": "https://shield-global-watch.herokuapp.com/",
+    "git_url": "git@heroku.com:shield-global-watch.git",
+    "last_release": "2014-12-12T02:16:59Z",
+    "unsafe_key": "Doomed if we're seeing this"
+  },
+  {
+    "name": "shield-global-watch-staging",
+    "web_url": "https://shield-global-watch-staging.herokuapp.com/",
+    "git_url": "git@heroku.com:shield-global-watch-staging.git",
+    "last_release": "2015-01-01T02:16:59Z",
+    "unsafe_key": "No one should be seeing this"
+  }
+]

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -42,6 +42,35 @@ describe "Heroku Commands", ->
     expect(commands).to.include("hubot heroku config:set <app> <KEY=value> - Set KEY to value. Case sensitive and overrides present key")
     expect(commands).to.include("hubot heroku config:unset <app> <KEY> - Unsets KEY, does not throw error if key is not present")
 
+  describe "heroku list apps <app name>", ->
+    beforeEach ->
+      mockHeroku
+        .get("/apps")
+        .replyWithFile(200, __dirname + "/fixtures/app-list.json")
+
+    describe "when given an argument <app name>", ->
+      it "returns a list of the apps filtered by <app name>", (done) ->
+        room.user.say "Damon", "hubot heroku list apps staging"
+
+        waitForReplies 3, room, ->
+          expect(room.messages[1][1]).to.equal("@Damon Listing apps matching: staging")
+          expect(room.messages[2][1]).to.not.contain(/shield-global-watch\b/)
+          expect(room.messages[2][1]).to.contain("shield-global-watch-staging")
+
+          done()
+
+    describe "when the command is called without arguments" , ->
+      it "returns a list of all apps", (done) ->
+        room.user.say "Damon", "hubot heroku list apps"
+
+        waitForReplies 3, room, ->
+          expect(room.messages[1][1]).to.equal("@Damon Listing all apps available...")
+          expect(room.messages[2][1]).to.match(/shield-global-watch\b/)
+          expect(room.messages[2][1]).to.contain("shield-global-watch-staging")
+
+          done()
+
+
   describe "heroku info <app>", ->
     it "gets information about the app's dynos", (done) ->
       mockHeroku

--- a/test/heroku-commands-spec.coffee
+++ b/test/heroku-commands-spec.coffee
@@ -30,9 +30,10 @@ describe "Heroku Commands", ->
   it "exposes help commands", ->
     commands = room.robot.commands.filter (command) -> command.slice(0,12) is "hubot heroku"
 
-    expect(commands).to.have.length(9)
+    expect(commands).to.have.length(10)
 
     expect(commands).to.include("hubot heroku info <app> - Returns useful information about the app")
+    expect(commands).to.include("hubot heroku list apps <app name filter> - Lists all apps or filtered by the name")
     expect(commands).to.include("hubot heroku dynos <app> - Lists all dynos and their status")
     expect(commands).to.include("hubot heroku releases <app> - Latest 10 releases")
     expect(commands).to.include("hubot heroku rollback <app> <version> - Rollback to a release")


### PR DESCRIPTION
## What's up? 

Been awhile since I got a chance to work on this. 

A few changes

- We were skipping tests when the auth is on and it's hardcoded in package.json. I haven't solved this yet, it's probably better to redesign the auth a little. This made the tests pass when some of them were actually failing. I removed the auth in tests. 

- `waitForReplies` instead of setting a timeout, that makes it try until the test pass, making the tests faster.

Finally the list all apps command :)  