### PR TITLE
add ps:scale command for scaling dynos

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Some commands (hubot help will be a better source of truth):
 - `hubot heroku config <app>` - Get config keys for the app. Values not given for security
 - `hubot heroku config:set <app> <KEY=value>` - Set KEY to value. Case sensitive and overrides present key
 - `hubot heroku config:unset <app> <KEY>` - Unsets KEY, does not throw error if key is not present
+- `hubot heroku ps:scale <app> <type>=<size>(:<quantity>)` - Scales dyno quantity up or down
 
 For example, `hubot heroku config:set API_KEY=12345`
 

--- a/src/scripts/heroku-commands.coffee
+++ b/src/scripts/heroku-commands.coffee
@@ -20,6 +20,7 @@
 #   hubot heroku config:set <app> <KEY=value> - Set KEY to value. Case sensitive and overrides present key
 #   hubot heroku config:unset <app> <KEY> - Unsets KEY, does not throw error if key is not present
 #   hubot heroku run rake <app> <task> - Runs a specific rake task
+#   hubot heroku ps:scale <app> <type>=<size>(:<quantity>) - Scales dyno quantity up or down
 #
 # Author:
 #   daemonsy
@@ -248,3 +249,19 @@ module.exports = (robot) ->
         tail: true
       , (error, session) ->
         respondToUser(msg, error, "View logs at: #{session.logplex_url}")
+
+  # Formations
+  robot.respond /heroku ps:scale (.+) ([^=]+)=([^:]+):(.*)$/i, (msg) ->
+    parameters = {}
+    appName = msg.match[1]
+    type = msg.match[2]
+    parameters.quantity = msg.match[3]
+    parameters.size = msg.match[4] if msg.match.size > 4
+
+    return unless auth(msg, appName)
+
+    msg.reply "Telling Heroku to scale #{type} dynos of #{appName}"
+
+    heroku.apps(appName).formation(type).update parameters, (error, formation) ->
+      output = "Heroku: now running #{formation.type} at #{formation.quantity}:#{formation.size}"
+      respondToUser(msg, error, output)

--- a/test/fixtures/ps-scale.json
+++ b/test/fixtures/ps-scale.json
@@ -1,0 +1,13 @@
+{
+  "app": {
+    "name": "shield-global-watch",
+    "id": "01234567-89ab-cdef-0123-456789abcdef"
+  },
+  "command": "bundle exec rails server -p $PORT",
+  "created_at": "2012-01-01T12:00:00Z",
+  "id": "01234567-89ab-cdef-0123-456789abcdef",
+  "quantity": 2,
+  "size": "standard-2X",
+  "type": "web",
+  "updated_at": "2012-01-01T12:00:00Z"
+}


### PR DESCRIPTION
Add a `ps:scale` command for changing the quantity and optionally the size of a dyno type.

Example usage:

`heroku ps:scale my-app worker=4:Standard-2X`
`heroku ps:scale my-app worker=1`

The command doesn't support:

* Batch updates (scaling multiple dyno types in one command) - I don't need this capability personally and didn't feel like coming up with a regex that could handle it ;)
* Getting the formation set as a string that can be passed to `ps:scale` - again, I don't have the need for the formatted string, and the raw information is available via `heroku dynos`

closes https://github.com/daemonsy/hubot-heroku/issues/29