### PR TITLE
Implement threaded replies if you're using Slack

### DIFF
--- a/src/responder.js
+++ b/src/responder.js
@@ -1,0 +1,13 @@
+const slackResponder = require("./responders/slack");
+const defaultResponder = require("./responders/default");
+
+const RESPONDERS = {
+  slack: slackResponder,
+  default: defaultResponder
+}
+
+module.exports = function(msg) {
+  let responder = RESPONDERS[msg.adapterName] || RESPONDERS.default;
+
+  return responder(msg);
+}

--- a/src/responders/default.js
+++ b/src/responders/default.js
@@ -1,0 +1,7 @@
+module.exports = function(msg) {
+  return {
+    say(message) {
+      msg.reply(message)
+    }
+  }
+}

--- a/src/responders/slack.js
+++ b/src/responders/slack.js
@@ -1,0 +1,11 @@
+module.exports = function(msg) {
+  return {
+    say(message) {
+      if (!msg.message.thread_ts) {
+        msg.message.thread_ts = msg.message.id;
+      }
+
+      msg.send(message)
+    }
+  }
+}

--- a/src/scripts/heroku-commands.js
+++ b/src/scripts/heroku-commands.js
@@ -125,7 +125,7 @@ module.exports = function(robot) {
         }
       }
 
-      return responder(msg).say(output.join("\n"));
+      responder(msg).say(output.join("\n"));
     });
   });
 
@@ -137,7 +137,7 @@ module.exports = function(robot) {
 
     responder(msg).say(`Getting releases for ${appName}`);
 
-    return heroku.get(`/apps/${appName}/releases`).then((releases) => {
+    heroku.get(`/apps/${appName}/releases`).then((releases) => {
       let output = [];
       if (releases) {
         output.push(`Recent releases of ${appName}`);
@@ -147,7 +147,7 @@ module.exports = function(robot) {
         }
       }
 
-      return responder(msg).say(output.join("\n"));
+      responder(msg).say(output.join("\n"));
     });
   });
 
@@ -166,7 +166,7 @@ module.exports = function(robot) {
 
         if (!release) { throw `Version ${version} not found for ${appName} :(`; }
 
-        return heroku.post(`/apps/${appName}/releases`, { body: { release: release.id } })
+        return heroku.post(`/apps/${appName}/releases`, { body: { release: release.id } });
       }).then(release => responder(msg).say(`Success! v${release.version} -> Rollback to ${version}`))
         .catch(error => responder(msg).say(error));
     }
@@ -183,9 +183,9 @@ module.exports = function(robot) {
     responder(msg).say(`Telling Heroku to restart ${appName}${dynoNameText}`);
 
     if (!dynoName) {
-      return heroku.delete(`/apps/${appName}/dynos`).then(app => responder(msg).say(`Heroku: Restarting ${appName}${dynoNameText}`));
+      heroku.delete(`/apps/${appName}/dynos`).then(app => responder(msg).say(`Heroku: Restarting ${appName}${dynoNameText}`));
     } else {
-      return heroku.delete(`/apps/${appName}/dynos/${dynoName}`).then(app => responder(msg).say(`Heroku: Restarting ${appName}${dynoNameText}`));
+      heroku.delete(`/apps/${appName}/dynos/${dynoName}`).then(app => responder(msg).say(`Heroku: Restarting ${appName}${dynoNameText}`));
     }
   });
 
@@ -197,7 +197,7 @@ module.exports = function(robot) {
 
     responder(msg).say(`Telling Heroku to migrate ${appName}`);
 
-    return heroku.post(`/apps/${appName}/dynos`, {
+    heroku.post(`/apps/${appName}/dynos`, {
       body: {
         command: "rake db:migrate",
         attach: false
@@ -222,9 +222,9 @@ module.exports = function(robot) {
 
     responder(msg).say(`Getting config keys for ${appName}`);
 
-    return heroku.get(`/apps/${appName}/config-vars`).then((configVars) => {
+    heroku.get(`/apps/${appName}/config-vars`).then((configVars) => {
       let listOfKeys = configVars && Object.keys(configVars).join(", ");
-      return responder(msg).say(listOfKeys);
+      responder(msg).say(listOfKeys);
     });
   });
 
@@ -256,7 +256,7 @@ module.exports = function(robot) {
 
     keyPair[key] = null;
 
-    return heroku.patch(`/apps/${appName}/config-vars`, {body: keyPair}).then(response => responder(msg).say(`Heroku: ${key} has been unset`));
+    heroku.patch(`/apps/${appName}/config-vars`, {body: keyPair}).then(response => responder(msg).say(`Heroku: ${key} has been unset`));
   });
 
   // Run Rake
@@ -268,7 +268,7 @@ module.exports = function(robot) {
 
     responder(msg).say(`Telling Heroku to run \`rake ${task}\` on ${appName}`);
 
-    return heroku.post(`/apps/${appName}/dynos`, {
+    heroku.post(`/apps/${appName}/dynos`, {
       body: {
         command: `rake ${task}`,
         attach: false

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,4 @@
 --require coffee-script/register
 --compilers coffee:coffee-script/register
+--timeout 500
+--recursive

--- a/test/responders/slack-spec.js
+++ b/test/responders/slack-spec.js
@@ -2,7 +2,6 @@ const slackResponder = require(process.cwd() + "/src/responders/slack");
 let { expect } = chai;
 
 describe("Slack Responder", () => {
-  console.log(slackResponder)
   describe("say", () => {
     it("sets the thread_ts to message.id for a first threaded reply", () => {
       let msg = {

--- a/test/responders/slack-spec.js
+++ b/test/responders/slack-spec.js
@@ -1,0 +1,23 @@
+const slackResponder = require(process.cwd() + "/src/responders/slack");
+let { expect } = chai;
+
+describe("Slack Responder", () => {
+  console.log(slackResponder)
+  describe("say", () => {
+    it("sets the thread_ts to message.id for a first threaded reply", () => {
+      let msg = {
+        message: {
+          id: "uuid",
+          thread_ts: undefined
+        },
+        send(message) {
+          return message;
+        }
+      }
+
+      slackResponder(msg).say("Migrating all the apps!");
+
+      expect(msg.message.thread_ts).to.equal("uuid");
+    });
+  });
+});


### PR DESCRIPTION
## What's up? 

This added threaded replies directly for Slack user. The main mechanics is to set `thread_ts` to `id` on the first reply. This reduces the noise and keeps subsequent replies threaded. 

<img width="594" alt="screen shot 2017-04-26 at 12 37 05 am" src="https://cloud.githubusercontent.com/assets/1251946/25418284/81beb70a-2a18-11e7-89aa-f210b40bd2e2.png">
